### PR TITLE
fix(doc): remove missing tests/ in examples

### DIFF
--- a/doc/source/L0_setup.rst
+++ b/doc/source/L0_setup.rst
@@ -437,7 +437,7 @@ folder. This works particularly well with the -x option, resulting
 in the tests being run in course order and stopping at the first
 failing test::
 
-  python -m pytest -x tests/
+  python -m pytest -x
 
 You should make sure that your code passes tests before moving on
 to the next exercise.


### PR DESCRIPTION
The tests/ directory doesn't exist, throwing an error prior to this patch. Also, PyTest should automatically detect a test/ or tests/ dir :)